### PR TITLE
[feat] addition of send_logs_to_loki Github Action

### DIFF
--- a/send-logs-to-loki/Readme.md
+++ b/send-logs-to-loki/Readme.md
@@ -1,0 +1,49 @@
+# Send Logs to Loki GitHub Action
+
+The **Send Logs to Loki** GitHub Action collects logs from all jobs in a GitHub Actions workflow and sends them to a Loki instance. Logs are labeled with metadata like job names, job IDs, and custom labels, making them easily searchable and organized in Loki.
+
+## Features
+
+- Aggregates logs from all jobs in a workflow, including job-specific logs.
+- Allows dynamic injection of custom labels.
+- Automatically retries fetching logs if they are not immediately available.
+
+## Inputs
+
+| Name            | Description                                              | Required | Default              |
+| --------------- | -------------------------------------------------------- | -------- | -------------------- |
+| `loki_endpoint` | Loki push endpoint                                       | Yes      |                      |
+| `labels`        | Custom labels for logs (comma-separated key=value pairs) | No       | job_id=<>``, job_name=<>` |
+| `github_token`  | GitHub token for API authentication                      | Yes      |                      |
+
+## Example Usage
+
+```yaml
+
+  - name: Send Logs to Loki
+    uses: skroutz/github-actions/send-logs-to-loki@latest
+    with:
+      loki_endpoint: "https://loki.example.com"
+      labels: "job=github-actions,run_id=${{ github.run_id }}"
+      github_token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+## How It Works
+
+1. **Log Aggregation**: The action iterates over all jobs in the workflow using the GitHub Actions API.
+2. **Log Retrieval**: Logs are fetched for completed jobs and skipped for jobs still in progress.
+3. **Log Transmission**: Logs are sent to Loki with the specified labels.
+
+## How to Configure
+
+- **Add Custom Labels**: Use the `labels` input to include additional metadata for your logs.
+  - Example: `labels: "job=github-actions,env=production"`
+- **Loki Endpoint**: Specify the Loki instance URL with `loki_endpoint`.
+
+By default, the `job_id` and `job_name` are automatically added as labels for each job. (Be mindful of cardinality!)
+
+## Known Limitations
+
+- Logs are only fetched for completed jobs. Logs for in-progress jobs will be skipped.
+- Timestamps in Loki are processed as arrived. Therefore Loki timestamps are injected at time of transmision, along with Github Actions real Timestamps. 
+

--- a/send-logs-to-loki/Readme.md
+++ b/send-logs-to-loki/Readme.md
@@ -10,22 +10,27 @@ The **Send Logs to Loki** GitHub Action collects logs from all jobs in a GitHub 
 
 ## Inputs
 
-| Name            | Description                                              | Required | Default              |
-| --------------- | -------------------------------------------------------- | -------- | -------------------- |
-| `loki_endpoint` | Loki push endpoint                                       | Yes      |                      |
-| `labels`        | Custom labels for logs (comma-separated key=value pairs) | No       | job_id=<>``, job_name=<>` |
-| `github_token`  | GitHub token for API authentication                      | Yes      |                      |
+| Name                    | Description                                                | Required | Default              |
+| ----------------------- | -----------------------------------------------------------| -------- | -------------------- |
+| `loki_endpoint`         | Loki push endpoint                                         | Yes      |                      |
+| `labels`                | Custom labels for logs (comma-separated key=value pairs)   | No       | `job=github-actions` |
+| `github_token`          | GitHub token for API authentication                        | Yes      |                      |
+| `max_retries`           | Maximum number of retry attempts for fetching logs per job | No      |  5                   |
+| `retry_interval_seconds`| Interval in seconds between retry attempts                 | No      |  10                   |
 
 ## Example Usage
 
 ```yaml
-
-  - name: Send Logs to Loki
-    uses: skroutz/github-actions/send-logs-to-loki@latest
-    with:
-      loki_endpoint: "https://loki.example.com"
-      labels: "job=github-actions,run_id=${{ github.run_id }}"
-      github_token: ${{ secrets.GITHUB_TOKEN }}
+- name: Set up Python
+  uses: actions/setup-python@v4
+  with:
+    python-version: '3.x'
+- name: Send Logs to Loki
+  uses: skroutz/github-actions/send-logs-to-loki@latest
+  with:
+    loki_endpoint: "https://loki.example.com"
+    labels: "job=github-actions,run_id=${{ github.run_id }}"
+    github_token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ## How It Works
@@ -39,11 +44,22 @@ The **Send Logs to Loki** GitHub Action collects logs from all jobs in a GitHub 
 - **Add Custom Labels**: Use the `labels` input to include additional metadata for your logs.
   - Example: `labels: "job=github-actions,env=production"`
 - **Loki Endpoint**: Specify the Loki instance URL with `loki_endpoint`.
+- **Retry Configuration**: Use the `max_retries` and `retry_interval_seconds` inputs to control log fetch retry behavior.
 
 By default, the `job_id` and `job_name` are automatically added as labels for each job. (Be mindful of cardinality!)
+
+## Dependencies
+
+This action requires **Python 3**. It is recommended to use the [official GitHub action](https://github.com/actions/setup-python) to ensure the correct Python version is installed:
+
+```yaml
+- name: Set up Python
+  uses: actions/setup-python@v4
+  with:
+    python-version: '3.x'
+```
 
 ## Known Limitations
 
 - Logs are only fetched for completed jobs. Logs for in-progress jobs will be skipped.
-- Timestamps in Loki are processed as arrived. Therefore Loki timestamps are injected at time of transmision, along with Github Actions real Timestamps. 
-
+- Timestamps in Loki are processed as arrived. Therefore Loki timestamps are injected at the time of transmission, along with GitHub Actions real Timestamps.

--- a/send-logs-to-loki/action.yml
+++ b/send-logs-to-loki/action.yml
@@ -11,6 +11,14 @@ inputs:
   github_token:
     description: "GitHub token for API authentication"
     required: true
+  max_retries:
+    description: "Maximum number of retry attempts for fetching logs"
+    required: false
+    default: "5"
+  retry_interval_seconds:
+    description: "Interval in seconds between retry attempts"
+    required: false
+    default: "10"
 
 runs:
   using: "composite"
@@ -28,4 +36,6 @@ runs:
         RUN_ID: ${{ github.run_id }}
         LOKI_ENDPOINT: ${{ inputs.loki_endpoint }}
         LABELS: ${{ inputs.labels }}
+        MAX_RETRIES: ${{ inputs.max_retries }}
+        RETRY_INTERVAL_SECONDS: ${{ inputs.retry_interval_seconds }}
       run: python3 ./send-logs-to-loki/push_logs.py

--- a/send-logs-to-loki/action.yml
+++ b/send-logs-to-loki/action.yml
@@ -1,0 +1,31 @@
+name: "Send Logs to Loki"
+description: "Aggregate all workflow logs and send them to Loki with injected labels"
+inputs:
+  loki_endpoint:
+    description: "Loki push endpoint"
+    required: true
+  labels:
+    description: "Custom labels for logs (comma-separated key=value pairs)"
+    required: false
+    default: "job=github-actions"
+  github_token:
+    description: "GitHub token for API authentication"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Dependencies
+      shell: bash
+      run: |
+        echo "Installing Python dependencies..."
+        pip install -r ./send-logs-to-loki/requirements.txt
+
+    - name: Fetch and Push Logs to Loki
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github_token }}
+        RUN_ID: ${{ github.run_id }}
+        LOKI_ENDPOINT: ${{ inputs.loki_endpoint }}
+        LABELS: ${{ inputs.labels }}
+      run: python3 ./send-logs-to-loki/push_logs.py

--- a/send-logs-to-loki/action.yml
+++ b/send-logs-to-loki/action.yml
@@ -27,7 +27,7 @@ runs:
       shell: bash
       run: |
         echo "Installing Python dependencies..."
-        pip install -r ./send-logs-to-loki/requirements.txt
+        pip install -r "$GITHUB_ACTION_PATH/requirements.txt"
 
     - name: Fetch and Push Logs to Loki
       shell: bash
@@ -38,4 +38,4 @@ runs:
         LABELS: ${{ inputs.labels }}
         MAX_RETRIES: ${{ inputs.max_retries }}
         RETRY_INTERVAL_SECONDS: ${{ inputs.retry_interval_seconds }}
-      run: python3 ./send-logs-to-loki/push_logs.py
+      run: python3 "$GITHUB_ACTION_PATH/push_logs.py"

--- a/send-logs-to-loki/push_logs.py
+++ b/send-logs-to-loki/push_logs.py
@@ -1,0 +1,103 @@
+import os
+import json
+import requests
+import re
+import time
+
+# Environment Variables
+GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
+RUN_ID = os.getenv("RUN_ID")
+LOKI_ENDPOINT = os.getenv("LOKI_ENDPOINT")
+LABELS = os.getenv("LABELS", "job=github-actions")
+GITHUB_REPO = os.getenv("GITHUB_REPOSITORY")
+HEADERS = {"Authorization": f"Bearer {GITHUB_TOKEN}", "Accept": "application/vnd.github.v3+json"}
+
+def sanitize_labels(labels):
+    """Sanitize labels to comply with Loki's label naming rules."""
+    sanitized = {}
+    for k, v in (item.split("=", 1) for item in labels.split(",") if "=" in item):
+        # Replace invalid characters while preserving valid ones (ASCII letters, digits, _, :)
+        key = re.sub(r"[^a-zA-Z0-9_:]", "_", k).lstrip("0123456789")
+        if not key or not re.match(r"^[a-zA-Z_:][a-zA-Z0-9_:]*$", key):
+            raise ValueError(f"Invalid label key after sanitization: '{k}'")
+        sanitized[key] = v
+    return sanitized
+
+def get_jobs(run_id):
+    """Fetch all jobs metadata for the current workflow run."""
+    print(f"Fetching job metadata for workflow run ID: {run_id}")
+    jobs_url = f"https://api.github.com/repos/{GITHUB_REPO}/actions/runs/{run_id}/jobs"
+    response = requests.get(jobs_url, headers=HEADERS)
+    if response.status_code != 200:
+        raise Exception(f"Failed to fetch jobs: {response.text}")
+    return response.json().get("jobs", [])
+
+def fetch_job_logs(job_id):
+    """Fetch logs for a specific job."""
+    logs_url = f"https://api.github.com/repos/{GITHUB_REPO}/actions/jobs/{job_id}/logs"
+    response = requests.get(logs_url, headers=HEADERS)
+    if response.status_code == 200:
+        return response.text.splitlines()
+    elif response.status_code == 403:
+        print(f"Logs not ready yet for job ID: {job_id}")
+        return []
+    else:
+        print(f"Failed to fetch logs for job {job_id}: {response.status_code}")
+        return []
+
+def push_to_loki(logs, labels, job_name=None, job_id=None):
+    """Push logs to Loki."""
+    # Add job name and job ID as additional labels if provided
+    if job_name:
+        labels += f",job_name={job_name}"
+    if job_id:
+        labels += f",job_id={job_id}"
+
+    # Sanitize labels before sending to Loki
+    sanitized_labels = sanitize_labels(labels)
+
+    payload = {
+        "streams": [
+            {
+                "stream": sanitized_labels,
+                "values": [[str(int(time.time() * 1e9)), log] for log in logs if log],  # Include timestamps
+            }
+        ]
+    }
+    print(f"Pushing logs to Loki: {LOKI_ENDPOINT}")
+    response = requests.post(f"{LOKI_ENDPOINT}/loki/api/v1/push", json=payload)
+    if response.status_code == 204:
+        print("Logs successfully sent to Loki.")
+    else:
+        print(f"Failed to send logs to Loki: {response.status_code}, {response.text}")
+
+def main():
+    jobs = get_jobs(RUN_ID)
+    for job in jobs:
+        job_id = job.get("id")
+        status = job.get("status")
+        name = job.get("name")
+        print(f"Processing job ID: {job_id} ({name}), Status: {status}")
+
+        if status != "completed":
+            print(f"Skipping job ID: {job_id} (status: {status})")
+            continue
+
+        logs_to_send = []
+        for attempt in range(1, 6):
+            print(f"Fetching logs for job ID: {job_id} (Attempt {attempt}/5)")
+            logs = fetch_job_logs(job_id)
+            if logs:
+                logs_to_send.extend(logs)
+                break  # Stop retrying once logs are fetched
+            print(f"No logs available yet for job ID: {job_id}. Retrying in 10 seconds...")
+            time.sleep(10)
+
+        if logs_to_send:
+            print(f"Sending {len(logs_to_send)} log lines to Loki for job {name}...")
+            push_to_loki(logs_to_send, LABELS, job_name=name, job_id=job_id)
+        else:
+            print(f"No logs to send for job {name}.")
+
+if __name__ == "__main__":
+    main()

--- a/send-logs-to-loki/requirements.txt
+++ b/send-logs-to-loki/requirements.txt
@@ -1,0 +1,1 @@
+requests


### PR DESCRIPTION
The **Send Logs to Loki** GitHub Action collects logs from all jobs in a GitHub Actions workflow and sends them to a Loki instance.

Logs are labeled with metadata like job names, job IDs, and custom labels, making them easily searchable and organized in Loki.